### PR TITLE
fix: no check for high atom numbers in atom_basis.target_token.nums

### DIFF
--- a/src/viperleed_jax/atom_basis.py
+++ b/src/viperleed_jax/atom_basis.py
@@ -157,7 +157,7 @@ class AtomBasis:
         # If nums are specified, apply the selection based on nums
         if target_token.nums is not None:
             # check range for nums
-            if any(num < 1 or num > len(self) for num in target_token.nums):
+            if any(num < 1 for num in target_token.nums):
                 msg = (
                     f'Invalid atom number for target: {target_token.target_str}'
                 )


### PR DESCRIPTION
This was causing errors for legitimate atom numbers, because the bulk atoms are not included in AtomBasis.scatterers. If slabs are not ordered by z coordinate, there will be atom numbers larger than the number of non-bulk atoms in the slab. Can be dropped without issues since there's a check whether the requested number matches the expected site type immediately afterwards.