### PR TITLE
Update dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,5 +9,12 @@ ViPErLEED in a open-source package for quantitative low-energy electron
 diffraction [LEED-*I*(*V*)]. Information on all parts of the ViPErLEED project
 can be found at <https://www.viperleed.org>.
 
+## GPU support
+Note that, to make use of GPU acceleration, you need to install the appropriate
+`jaxlib` version. See https://docs.jax.dev/en/latest/installation.html
+for details. Make sure to select the correct architecture (e.g. NVIDIA vs AMD)
+and CUDA version (e.g. 12 vs 13) when installing `jaxlib`.
+
+
 ## Reporting bugs
 The preferred method of contacting the developers is via GitHub issues.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,14 +10,19 @@ requires-python = '>=3.7'
 version = '0.10.0'
 license = {file = 'LICENSE'}
 
+# Note: To use GPU acceleration, users will need to install the appropriate
+# jaxlib version. See https://docs.jax.dev/en/latest/installation.html for
+# details. Make sure to select the correct architecture (e.g. NVIDIA vs AMD)
+# and CUDA version (e.g. 12 vs 13) when installing jaxlib.
 dependencies = [
-    'jax',
+    'jax >= 0.8.3',
     'clinamen2>=2024.7.1',
-    'numpy<2',
+    'numpy>=2.0',
     'viperleed>=0.14.1',
     'spbessax>=0.1.3',
     'tqdm',
-    'interpax<=0.3.7',
+    'interpax>=0.3.13',
+    'equinox>=0.13',
     'anytree',
     ]
 


### PR DESCRIPTION
We've had issues with hard to diagnose bugs in the `interpax` dependency, which in version `0.3.8` introduced some changes in how it used the `equinox` libaray. Those changes lead to crashes down the line in `viperleed-jax`, and forced us to fix `interpax` at versions `<=0.3.7`, which in turn limited the compatible `jax` version.

I've now tested out compatibitly with the more recent versions of `jax`, `jaxlib`, `interpax` and `equinox`. This issue seems to be resolved now, allowing us to use more current versions.
Based on this, I've updated the `pyproject.toml` file.
I've also added a note on installing the correct `jaxlib` version for GPU acceleration, as by default only the CPU version of `jaxlib` is installed. Users need to install the correct `jaxlib` version for their architecture (e.g. NVIDIA GPUs vs AMD GPUs) and select the correct CUDA version for NVIDIA GPUs(e.g. CUDA 12 vs CUDA 13).

I've tested this with the CPU version of JAX on macOS and with the GPU version of JAX on Linux with a NVIDIA GPU.
@michele-riva, could you please test this on your Windows machine?